### PR TITLE
Add basic session support for source plugins

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -27,7 +27,11 @@ export default {
   /*
    ** Plugins to load before mounting the App
    */
-  plugins: ['@/plugins/vuex-orm-axios', '@/plugins/vue-json-edit'],
+  plugins: [
+    '@/plugins/vuex-orm-axios',
+    '@/plugins/vue-json-edit',
+    '@/plugins/persistedState.client',
+  ],
   /*
    ** Nuxt.js dev-modules
    */

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "timestring": "^6.0.0",
     "vue": "^2.6.12",
     "vue-json-edit": "^1.4.3",
-    "vuex": "^3.6.0"
+    "vuex": "^3.6.0",
+    "vuex-persistedstate": "^3.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",

--- a/pages/source/config_item_list/_sourceId/_configItemId/edit.vue
+++ b/pages/source/config_item_list/_sourceId/_configItemId/edit.vue
@@ -44,16 +44,26 @@ import Source from '~/models/Source'
 export default {
   components: { FormGenerator },
   layout: 'nonfluid',
-  async asyncData({ $axios, params }) {
+  async asyncData({ $axios, params, store }) {
     const { data: schema } = await $axios.get(
       `/source/${params.sourceId}/config_item/${encodeURIComponent(
         params.configItemId
-      )}/input_form`
+      )}/input_form`,
+      {
+        params: {
+          session: store.state.session.sessionKey,
+        },
+      }
     )
     const { data: formData } = await $axios.get(
       `/source/${params.sourceId}/config_item/${encodeURIComponent(
         params.configItemId
-      )}`
+      )}`,
+      {
+        params: {
+          session: store.state.session.sessionKey,
+        },
+      }
     )
     return {
       sourceId: params.sourceId,
@@ -77,7 +87,12 @@ export default {
         `/source/${this.sourceId}/config_item/${encodeURIComponent(
           this.$route.params.configItemId
         )}`,
-        formData
+        formData,
+        {
+          params: {
+            session: this.$store.state.session.sessionKey,
+          },
+        }
       )
       if (status === 200) {
         this.$toast.success('Updated configuration item!')

--- a/pages/source/config_item_list/_sourceId/_configItemId/index.vue
+++ b/pages/source/config_item_list/_sourceId/_configItemId/index.vue
@@ -76,7 +76,12 @@ export default {
     const { data } = await $axios.get(
       `/source/${params.sourceId}/config_item/${encodeURIComponent(
         params.configItemId
-      )}/metrics`
+      )}/metrics`,
+      {
+        params: {
+          session: this.$store.state.session.sessionKey,
+        },
+      }
     )
     return {
       id: params.sourceId,
@@ -124,6 +129,11 @@ export default {
           notSelectedMetrics: this.availableMetrics
             .filter((el) => !el.selected)
             .map((item) => item.id),
+        },
+        {
+          params: {
+            session: this.$store.state.session.sessionKey,
+          },
         }
       )
       if (status === 200) {
@@ -142,7 +152,12 @@ export default {
         )
         if (answer) {
           const { status } = await this.$axios.post(
-            `/source/${this.$route.params.sourceId}/save_reconfigure`
+            `/source/${this.$route.params.sourceId}/save_reconfigure`,
+            {
+              params: {
+                session: this.$store.state.session.sessionKey,
+              },
+            }
           )
           if (status === 200) {
             this.$toast.success(

--- a/pages/source/config_item_list/_sourceId/add_configuration_item.vue
+++ b/pages/source/config_item_list/_sourceId/add_configuration_item.vue
@@ -44,9 +44,14 @@ import Source from '~/models/Source'
 export default {
   components: { FormGenerator },
   layout: 'nonfluid',
-  async asyncData({ $axios, params }) {
+  async asyncData({ $axios, params, store }) {
     const { data } = await $axios.get(
-      `/source/${params.sourceId}/config_items/input_form`
+      `/source/${params.sourceId}/config_items/input_form`,
+      {
+        params: {
+          session: store.state.session.sessionKey,
+        },
+      }
     )
     return {
       sourceId: params.sourceId,
@@ -68,7 +73,12 @@ export default {
       this.adding = true
       const { status } = await this.$axios.post(
         `/source/${this.sourceId}/config_items`,
-        formData
+        formData,
+        {
+          params: {
+            session: this.$store.state.session.sessionKey,
+          },
+        }
       )
       if (status === 200) {
         this.$toast.success('Added configuration item!')

--- a/pages/source/config_item_list/_sourceId/edit_global_configuration.vue
+++ b/pages/source/config_item_list/_sourceId/edit_global_configuration.vue
@@ -44,11 +44,20 @@ import Source from '~/models/Source'
 export default {
   components: { FormGenerator },
   layout: 'nonfluid',
-  async asyncData({ $axios, params }) {
+  async asyncData({ $axios, params, store }) {
     const { data: schema } = await $axios.get(
-      `/source/${params.sourceId}/input_form`
+      `/source/${params.sourceId}/input_form`,
+      {
+        params: {
+          session: store.state.session.sessionKey,
+        },
+      }
     )
-    const { data: formData } = await $axios.get(`/source/${params.sourceId}`)
+    const { data: formData } = await $axios.get(`/source/${params.sourceId}`, {
+      params: {
+        session: store.state.session.sessionKey,
+      },
+    })
     return {
       sourceId: params.sourceId,
       schema,
@@ -69,7 +78,12 @@ export default {
       this.updating = true
       const { status } = await this.$axios.post(
         `/source/${this.sourceId}`,
-        formData
+        formData,
+        {
+          params: {
+            session: this.$store.state.session.sessionKey,
+          },
+        }
       )
       if (status === 200) {
         this.$toast.success('Updated global config!')
@@ -88,7 +102,12 @@ export default {
         )
         if (answer) {
           const { status } = await this.$axios.post(
-            `/source/${this.$route.params.sourceId}/save_reconfigure`
+            `/source/${this.$route.params.sourceId}/save_reconfigure`,
+            {
+              params: {
+                session: this.$store.state.session.sessionKey,
+              },
+            }
           )
           if (status === 200) {
             this.$toast.success(

--- a/pages/source/config_item_list/_sourceId/index.vue
+++ b/pages/source/config_item_list/_sourceId/index.vue
@@ -90,8 +90,15 @@ import Source from '~/models/Source'
 
 export default {
   components: {},
-  async asyncData({ $axios, params }) {
-    const { data } = await $axios.get(`/source/${params.sourceId}/config_items`)
+  async asyncData({ $axios, params, store }) {
+    const { data } = await $axios.get(
+      `/source/${params.sourceId}/config_items`,
+      {
+        params: {
+          session: store.state.session.sessionKey,
+        },
+      }
+    )
     await Source.update({
       where: params.sourceId,
       data: { configItemName: data.configItemName },
@@ -124,12 +131,22 @@ export default {
       )
       if (answer) {
         const { status } = await this.$axios.delete(
-          `/source/${this.id}/config_item/${encodeURIComponent(configItem.id)}`
+          `/source/${this.id}/config_item/${encodeURIComponent(configItem.id)}`,
+          {
+            params: {
+              session: this.$store.state.session.sessionKey,
+            },
+          }
         )
         if (status === 200) {
           this.$toast.success('Deleted configuration item!')
           const { data } = await this.$axios.get(
-            `/source/${this.id}/config_items`
+            `/source/${this.id}/config_items`,
+            {
+              params: {
+                session: this.$store.state.session.sessionKey,
+              },
+            }
           )
           this.configurationItems = data
         } else {

--- a/plugins/persistedState.client.js
+++ b/plugins/persistedState.client.js
@@ -1,0 +1,7 @@
+import createPersistedState from 'vuex-persistedstate'
+
+export default ({ store }) => {
+  createPersistedState({
+    paths: ['session'],
+  })(store)
+}

--- a/store/session.js
+++ b/store/session.js
@@ -1,0 +1,5 @@
+export const state = () => ({
+  sessionKey: Math.random().toString(20).substr(2, 10),
+})
+
+export const mutations = {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9600,6 +9600,11 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+shvl@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/shvl/-/shvl-2.0.3.tgz#eb4bd37644f5684bba1fc52c3010c96fb5e6afd1"
+  integrity sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -10868,6 +10873,14 @@ vuedraggable@^2.23.2:
   integrity sha512-6/HDXi92GzB+Hcs9fC6PAAozK1RLt1ewPTLjK0anTYguXLAeySDmcnqE8IC0xa7shvSzRjQXq3/+dsZ7ETGF3g==
   dependencies:
     sortablejs "1.10.2"
+
+vuex-persistedstate@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-3.2.1.tgz#85b05bdfa73e602b00c65e54698a690345c07cdf"
+  integrity sha512-0OnHKGsCHJcvbEraaGZvuvX4aybM2oQWYRuZmIQB7zUjVM6tP+Hg+oXLrq9r6elT4she9SGtEbGE1L2+XdFgUw==
+  dependencies:
+    deepmerge "^4.2.2"
+    shvl "^2.0.3"
 
 vuex@^3.6.0, vuex@^3.6.2:
   version "3.6.2"


### PR DESCRIPTION
This adds basic support for session support introduced in metricq/metricq-wizard-backend@845271565342ceaee7f897c22325f98939225bd7

A session key is generated at first "startup" and then stored in persistent browser store and never renewed. This helps distinguish between different users (aka browsers), but nothing else.