### PR TITLE
feat: raw config without reserved CouchDB fields

### DIFF
--- a/pages/client/edit_json/_clientId/index.vue
+++ b/pages/client/edit_json/_clientId/index.vue
@@ -48,9 +48,12 @@ export default {
   async asyncData({ $axios, params }) {
     const { data } = await $axios.get(`/source/${params.clientId}/raw_config`)
 
+    const { _rev, ...config } = data.config
+
     return {
       clientId: params.clientId,
-      jsonData: data.config,
+      jsonData: config,
+      configRev: _rev,
       updating: false,
       showJsonEditor: JSON.stringify(data.config).length < 10000,
     }
@@ -60,7 +63,7 @@ export default {
       this.updating = true
       const { status } = await this.$axios.post(
         `/source/${this.clientId}/raw_config`,
-        this.jsonData
+        { _rev: this.configRev, ...this.jsonData }
       )
       if (status === 200) {
         this.$toast.success('Saved config!')

--- a/pages/source/edit_json/_sourceId/index.vue
+++ b/pages/source/edit_json/_sourceId/index.vue
@@ -49,9 +49,12 @@ export default {
   async asyncData({ $axios, params }) {
     const { data } = await $axios.get(`/source/${params.sourceId}/raw_config`)
 
+    const { _rev, ...config } = data.config
+
     return {
       sourceId: params.sourceId,
-      jsonData: data.config,
+      jsonData: config,
+      configRev: _rev,
       updating: false,
       showJsonEditor: JSON.stringify(data.config).length < 10000,
     }
@@ -66,7 +69,7 @@ export default {
       this.updating = true
       const { status } = await this.$axios.post(
         `/source/${this.sourceId}/raw_config`,
-        this.jsonData
+        { _rev: this.configRev, ...this.jsonData }
       )
       if (status === 200) {
         this.$toast.success('Saved config!')


### PR DESCRIPTION
This stores the _rev field instead of showing it to the user.