### PR TITLE
ui: move some data from client list to detail page

### DIFF
--- a/pages/client/_clientId.vue
+++ b/pages/client/_clientId.vue
@@ -44,13 +44,22 @@
             <b-card no-body>
               <b-row v-if="client.discoverTime">
                 <b-col v-if="client.hostname" align="left" class="m-3">
-                  Runs on {{ client.hostname }}
-                  <template v-if="client.version">
-                    (Version {{ client.version }})
-                  </template>
-                  <template v-if="client.metricqVersion">
-                    using MetricQ {{ client.metricqVersion }}
-                  </template>
+                  <p class="lead pb-2">
+                    Runs on <b-icon-hdd-network />
+                    <strong>{{ client.hostname }}</strong>
+                    since {{ client.startingTime | momentAgo }}
+                  </p>
+                  <p>
+                    <template v-if="client.version">
+                      Version <b-icon-box-seam /> {{ client.version }}
+                    </template>
+                    <template v-if="client.metricqVersion">
+                      using MetricQ {{ client.metricqVersion }}
+                    </template>
+                  </p>
+                  <p class="text-right blockquote-footer">
+                    Last update from {{ client.lastseen | momentAgo }}
+                  </p>
                 </b-col>
               </b-row>
               <b-alert v-else variant="warning" show class="mb-0">

--- a/pages/client/_clientId.vue
+++ b/pages/client/_clientId.vue
@@ -50,12 +50,9 @@
                     since {{ client.startingTime | momentAgo }}
                   </p>
                   <p>
-                    <template v-if="client.version">
-                      Version <b-icon-box-seam /> {{ client.version }}
-                    </template>
-                    <template v-if="client.metricqVersion">
-                      using MetricQ {{ client.metricqVersion }}
-                    </template>
+                    <b-icon-box-seam /> Version
+                    {{ client.version || 'unknown' }} with MetricQ version
+                    {{ client.metricqVersion || 'unknown' }}
                   </p>
                   <p class="text-right blockquote-footer">
                     Last update from {{ client.lastseen | momentAgo }}

--- a/pages/client/list.vue
+++ b/pages/client/list.vue
@@ -93,17 +93,17 @@
                 </template>
                 <template v-else>never seen</template>
               </template>
-              <template #head(actions)="data">
-                <span class="float-right">{{ data.label }}</span>
-              </template>
-              <template #cell(actions)="data">
-                <client-actions :client="data.item" />
-              </template>
               <template #head(startingTime)> Started </template>
               <template #cell(startingTime)="data">
                 <template v-if="data.item.startingTime">
                   {{ data.item.startingTime | momentAgo }}
                 </template>
+              </template>
+              <template #head(actions)="data">
+                <span class="float-right">{{ data.label }}</span>
+              </template>
+              <template #cell(actions)="data">
+                <client-actions :client="data.item" />
               </template>
               <template #emptyfiltered>
                 <b-jumbotron

--- a/pages/client/list.vue
+++ b/pages/client/list.vue
@@ -125,21 +125,37 @@
                 </b-jumbotron>
               </template>
             </b-table>
-            <b-card-footer class="d-flex justify-content-between">
-              <span class="lead">
-                Total clients: {{ clients.length }}
-                <template v-if="filter">({{ totalRows }} matching)</template>
-              </span>
-              <b-pagination
-                v-if="clients.length > perPage"
-                v-model="currentPage"
-                :total-rows="totalRows"
-                :per-page="perPage"
-                first-number
-                last-number
-                class="d-flex justify-content-center"
-              />
-              <div />
+            <b-card-footer>
+              <b-row align-v="center">
+                <b-col>
+                  <span>
+                    Total clients: {{ clients.length }}
+                    <template v-if="filter">
+                      ({{ totalRows }} matching)
+                    </template>
+                  </span>
+                </b-col>
+                <b-col>
+                  <b-pagination
+                    v-if="clients.length > perPage"
+                    v-model="currentPage"
+                    :total-rows="totalRows"
+                    :per-page="perPage"
+                    first-number
+                    last-number
+                    class="justify-content-center"
+                  />
+                </b-col>
+                <b-col class="text-right">
+                  Clients per page
+                  <b-form-select
+                    v-model="perPage"
+                    :options="[10, 20, 50, 100, 200, 500]"
+                    size="sm"
+                    class="w-25"
+                  />
+                </b-col>
+              </b-row>
             </b-card-footer>
           </b-card>
         </b-overlay>
@@ -171,7 +187,7 @@ export default {
     return {
       filter: null,
       showReScanOverlay: false,
-      perPage: 16,
+      perPage: 20,
       currentPage: 1,
       totalRows: 0,
       dependencies: null,

--- a/pages/client/list.vue
+++ b/pages/client/list.vue
@@ -65,6 +65,9 @@
               :fields="[
                 { key: 'id', sortable: true },
                 { key: 'hostname', sortable: true },
+                { key: 'version', sortable: true },
+                { key: 'metricqVersion', sortable: true },
+                { key: 'startingTime', sortable: true },
                 { key: 'lastseen', sortable: true },
                 { key: 'actions' },
               ]"
@@ -95,6 +98,12 @@
               </template>
               <template #cell(actions)="data">
                 <client-actions :client="data.item" />
+              </template>
+              <template #head(startingTime)> Started </template>
+              <template #cell(startingTime)="data">
+                <template v-if="data.item.startingTime">
+                  {{ data.item.startingTime | momentAgo }}
+                </template>
               </template>
               <template #emptyfiltered>
                 <b-jumbotron

--- a/pages/client/list.vue
+++ b/pages/client/list.vue
@@ -41,12 +41,11 @@
                       debounce="200"
                       :autofocus="true"
                       placeholder="Type to Search"
-                    ></b-form-input>
-
+                    />
                     <b-input-group-append>
-                      <b-button :disabled="!filter" @click="filter = ''"
-                        >Clear</b-button
-                      >
+                      <b-button :disabled="!filter" @click="filter = ''">
+                        Clear
+                      </b-button>
                     </b-input-group-append>
                   </b-input-group>
                 </b-col>

--- a/pages/client/list.vue
+++ b/pages/client/list.vue
@@ -65,9 +65,6 @@
               :fields="[
                 { key: 'id', sortable: true },
                 { key: 'hostname', sortable: true },
-                { key: 'version', sortable: true },
-                { key: 'metricqVersion', sortable: true },
-                { key: 'startingTime', sortable: true },
                 { key: 'lastseen', sortable: true },
                 { key: 'actions' },
               ]"
@@ -93,13 +90,6 @@
                 </template>
                 <template v-else>never seen</template>
               </template>
-              <template #head(startingTime)> Started </template>
-              <template #cell(startingTime)="data">
-                <template v-if="data.item.startingTime">
-                  {{ data.item.startingTime | momentAgo }}
-                </template>
-              </template>
-
               <template #head(actions)="data">
                 <span class="float-right">{{ data.label }}</span>
               </template>


### PR DESCRIPTION
Moves version, metricq version and starting time to the client detail page, freeing up space in the client list table 