### PR TITLE
ui: humanized rate in metric workshop table

### DIFF
--- a/components/MetricTable.vue
+++ b/components/MetricTable.vue
@@ -48,7 +48,7 @@
             </b-link>
           </template>
           <template #cell(rate)="data">
-            {{ data.item.rate }}
+            {{ data.item.rate | humanizeRate }}
           </template>
           <template #cell(lastMetadataUpdate)="data">
             {{

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -34,7 +34,7 @@ export default {
     '@/plugins/vue-json-edit',
     '@/plugins/vue-json-tree',
     '@/plugins/persistedState.client',
-    '@/plugins/moment-filter',
+    '@/plugins/filters',
     '@/plugins/async-computed',
     '@/plugins/chartkick',
     '@/plugins/sleep',

--- a/plugins/filters.js
+++ b/plugins/filters.js
@@ -18,3 +18,19 @@ Vue.filter('momentDuration', function (duration) {
     return moment.duration(duration, 'seconds').humanize()
   }
 })
+
+Vue.filter('humanizeRate', function (rate) {
+  // we get a float representing the sampling rate
+  // so let's calculate an interval
+  const interval = moment.duration(1 / rate, 'seconds')
+
+  if (interval.asHours() >= 1) {
+    return `1 / ${interval.asHours()} h`
+  } else if (interval.asMinutes() >= 1) {
+    return `1 / ${interval.asMinutes()} min`
+  } else if (interval.asSeconds() > 1) {
+    return `1 / ${interval.asSeconds()} s`
+  } else {
+    return `${parseFloat(rate.toFixed(2))} Hz`
+  }
+})

--- a/plugins/filters.js
+++ b/plugins/filters.js
@@ -20,8 +20,9 @@ Vue.filter('momentDuration', function (duration) {
 })
 
 Vue.filter('humanizeRate', function (rate) {
-  // we get a float representing the sampling rate
-  // so let's calculate an interval
+  // get a rate as Number and return a human-readable
+  // string representation of that rate
+
   const interval = moment.duration(1 / rate, 'seconds')
 
   if (interval.asHours() >= 1) {
@@ -31,6 +32,8 @@ Vue.filter('humanizeRate', function (rate) {
   } else if (interval.asSeconds() > 1) {
     return `1 / ${interval.asSeconds()} s`
   } else {
+    // JavaScript is weird. This abomination prints floats
+    // with at most two fractional digits, but no trailing zeros.
     return `${parseFloat(rate.toFixed(2))} Hz`
   }
 })


### PR DESCRIPTION
If the rate is less than 1Hz, it prints as `1 / N [s|min|h]`. For rates greater or equal 1 Hz, it prints a rounded number.