### PR TITLE
ui: make button tooltips noninteractive

### DIFF
--- a/components/ClientActions.vue
+++ b/components/ClientActions.vue
@@ -15,7 +15,7 @@
       </b-button>
       <b-button
         v-if="client.hasConfiguration"
-        v-b-tooltip.hover
+        v-b-tooltip.hover.noninteractive
         :to="{
           name: 'client-edit_json-clientId',
           params: { clientId: client.id },
@@ -26,7 +26,7 @@
       </b-button>
       <b-button
         v-if="showDetails"
-        v-b-tooltip.hover
+        v-b-tooltip.hover.noninteractive
         :to="{
           name: 'client-clientId',
           params: { clientId: client.id },
@@ -37,7 +37,7 @@
         <b-icon-search scale="1.5" />
       </b-button>
       <b-button
-        v-b-tooltip.hover
+        v-b-tooltip.hover.noninteractive
         variant="danger"
         title="Send config to client"
         @click="reconfigureClient(client)"

--- a/components/MetricListCard.vue
+++ b/components/MetricListCard.vue
@@ -39,7 +39,7 @@
           </b-col>
           <b-col class="text-right float-right">
             <b-button
-              v-b-tooltip.hover
+              v-b-tooltip.hover.noninteractive
               :to="{
                 name: 'metric-metricId',
                 params: { metricId: metric },


### PR DESCRIPTION
Noninteractive tooltips are hidden as soon as the cursor leaves the
target element. Hence, when you have a lot of these buttons in a table
or list, the tooltip doesn't stay when moving the cursor to
the next button.