### PR TITLE
ui: fix metric table jumping

### DIFF
--- a/pages/metric/configure.vue
+++ b/pages/metric/configure.vue
@@ -490,7 +490,15 @@ export default {
     onFiltered(_filteredItems, filteredItemsCount) {
       // Trigger pagination to update the number of buttons/pages due to filtering
       this.totalRows = filteredItemsCount
-      this.currentPage = 1
+
+      // We need to update the currentPage to be within the bounds
+      // of the filtered items. But, we shouldn't change the page
+      // unless it is absolutely necessary, because this method
+      // will also be called, when a user selects a metric.
+      this.currentPage = Math.min(
+        this.currentPage,
+        Math.ceil(filteredItemsCount / this.pageSize)
+      )
     },
     async loadByDatabase() {
       Metric.commit((state) => {


### PR DESCRIPTION
This fixes a bug that occurs, when a user loads at least two pages
worth of metrics, is on another page when page 1 and selects a
metric. Once the metric is selected, this changes the model, hence
the table needs to rerender, which moves the pagination to page 1