### PR TITLE
Allow clients to be deleted

### DIFF
--- a/components/ClientActions.vue
+++ b/components/ClientActions.vue
@@ -3,7 +3,7 @@
     <b-button-group v-if="client" size="sm" class="shadow-sm">
       <b-button
         v-if="client.configurable"
-        v-b-tooltip.hover
+        v-b-tooltip.hover.noninteractive
         :to="{
           name: 'source-config_item_list-sourceId',
           params: { sourceId: client.id },
@@ -44,6 +44,15 @@
       >
         <b-icon-bootstrap-reboot scale="1.5" />
       </b-button>
+      <b-button
+        v-if="showDelete"
+        v-b-tooltip.hover.noninteractive
+        variant="warning"
+        title="Delete the client"
+        @click="deleteClient(client)"
+      >
+        <b-icon-trash scale="1.5" />
+      </b-button>
     </b-button-group>
     <b-icon-exclamation-diamond v-else variant="danger" />
   </div>
@@ -53,7 +62,11 @@
 import Client from '~/models/Client'
 
 export default {
-  props: { client: Client, showDetails: { type: Boolean, default: true } },
+  props: {
+    client: Client,
+    showDetails: { type: Boolean, default: true },
+    showDelete: { type: Boolean, default: false },
+  },
   methods: {
     async reconfigureClient(client) {
       const reconfigureConfirmed = await this.$bvModal.msgBoxConfirm(
@@ -73,10 +86,38 @@ export default {
       if (reconfigureConfirmed) {
         const { response } = await client.reconfigure()
 
-        if (response.status / 100 === 2) {
+        if (response.status === 200) {
           this.$toast.success('Requested Client reconfiguration!')
         } else {
           this.$toast.error('Client reconfiguration failed!')
+        }
+      }
+    },
+    async deleteClient(client) {
+      const deleteConfirmed = await this.$bvModal.msgBoxConfirm(
+        `Really delete ${client.id}?`,
+        {
+          title: 'Please Confirm',
+          buttonSize: 'sm',
+          okVariant: 'danger',
+          okTitle: 'YES',
+          cancelTitle: 'NO',
+          footerClass: 'p-2',
+          hideHeaderClose: false,
+          centered: true,
+        }
+      )
+
+      if (deleteConfirmed) {
+        const { response } = await client.delete()
+
+        if (response.status === 200) {
+          this.$toast.success('Successfully deleted the client configuration!')
+          this.$router.push({
+            name: 'client-list',
+          })
+        } else {
+          this.$toast.error('Failed to delete the client!')
         }
       }
     },

--- a/models/Client.js
+++ b/models/Client.js
@@ -43,10 +43,14 @@ export class Client extends Model {
   }
 
   async delete() {
-    return await Client.api().delete(`/client/${this.id}`, {
+    const response = await Client.api().delete(`/client/${this.id}`, {
       save: false,
       validateStatus: null,
     })
+
+    this.$delete()
+
+    return response
   }
 
   static async fetchProducedMetrics(clientId) {

--- a/models/Client.js
+++ b/models/Client.js
@@ -48,7 +48,7 @@ export class Client extends Model {
       validateStatus: null,
     })
 
-    this.$delete()
+    if (response.response.status === 200) this.$delete()
 
     return response
   }

--- a/models/Client.js
+++ b/models/Client.js
@@ -42,6 +42,13 @@ export class Client extends Model {
     })
   }
 
+  async delete() {
+    return await Client.api().delete(`/client/${this.id}`, {
+      save: false,
+      validateStatus: null,
+    })
+  }
+
   static async fetchProducedMetrics(clientId) {
     const { response } = await Client.api().get(
       `/client/${clientId}/produced_metrics`,

--- a/pages/client/_clientId.vue
+++ b/pages/client/_clientId.vue
@@ -25,6 +25,8 @@
                 <client-actions
                   v-if="client"
                   :show-details="false"
+                  :show-delete="true"
+                  :show-create="true"
                   :client="client"
                 />
               </b-col>

--- a/pages/client/_clientId.vue
+++ b/pages/client/_clientId.vue
@@ -26,7 +26,6 @@
                   v-if="client"
                   :show-details="false"
                   :show-delete="true"
-                  :show-create="true"
                   :client="client"
                 />
               </b-col>

--- a/pages/client/list.vue
+++ b/pages/client/list.vue
@@ -98,7 +98,7 @@
                 <span class="float-right">{{ data.label }}</span>
               </template>
               <template #cell(actions)="data">
-                <client-actions :client="data.item" />
+                <client-actions :show-delete="true" :client="data.item" />
               </template>
               <template #emptyfiltered>
                 <b-jumbotron


### PR DESCRIPTION
This adds a delete button to the client overview and client details pages through the `ClientActions` component.

Requires https://github.com/metricq/metricq-wizard-backend/pull/48