### PR TITLE
Feat-cross-linking-metrics

### DIFF
--- a/components/ClientActions.vue
+++ b/components/ClientActions.vue
@@ -2,6 +2,15 @@
   <div class="text-right">
     <b-button-group v-if="client" size="sm" class="shadow-sm">
       <b-button
+        v-if="isSource"
+        v-b-tooltip.hover.noninteractive
+        variant="dark"
+        title="Load all metrics into Metric Workshop"
+        @click="loadClientMetrics(client.id)"
+      >
+        <b-icon-bookmarks scale="1.3" />
+      </b-button>
+      <b-button
         v-if="client.configurable"
         v-b-tooltip.hover.noninteractive
         :to="{
@@ -11,7 +20,7 @@
         variant="primary"
         title="Edit client config"
       >
-        <b-icon-wrench scale="1.5" />
+        <b-icon-wrench scale="1.3" />
       </b-button>
       <b-button
         v-if="client.hasConfiguration"
@@ -22,7 +31,7 @@
         }"
         title="Edit raw JSON config"
       >
-        <b-icon-file-text scale="1.5" />
+        <b-icon-file-text scale="1.3" />
       </b-button>
       <b-button
         v-if="showDetails"
@@ -34,7 +43,7 @@
         title="Client Details"
         variant="info"
       >
-        <b-icon-search scale="1.5" />
+        <b-icon-search scale="1.3" />
       </b-button>
       <b-button
         v-b-tooltip.hover.noninteractive
@@ -42,7 +51,7 @@
         title="Send config to client"
         @click="reconfigureClient(client)"
       >
-        <b-icon-bootstrap-reboot scale="1.5" />
+        <b-icon-bootstrap-reboot scale="1.3" />
       </b-button>
       <b-button
         v-if="showDelete"
@@ -51,7 +60,7 @@
         title="Delete the client"
         @click="deleteClient(client)"
       >
-        <b-icon-trash scale="1.5" />
+        <b-icon-trash scale="1.3" />
       </b-button>
     </b-button-group>
     <b-icon-exclamation-diamond v-else variant="danger" />
@@ -60,12 +69,21 @@
 
 <script>
 import Client from '~/models/Client'
+import Metric from '~/models/Metric'
 
 export default {
   props: {
     client: Client,
     showDetails: { type: Boolean, default: true },
     showDelete: { type: Boolean, default: false },
+  },
+  computed: {
+    isSource() {
+      return (
+        this.client.id.startsWith('source-') ||
+        this.client.id.startsWith('transformer-')
+      )
+    },
   },
   methods: {
     async reconfigureClient(client) {
@@ -120,6 +138,39 @@ export default {
           this.$toast.error('Failed to delete the client!')
         }
       }
+    },
+    async loadClientMetrics(client) {
+      Metric.commit((state) => {
+        state.fetching = true
+      })
+
+      let dataTransformer = Metric.convertMetricListResponse
+
+      if (client.startsWith('transformer-') && client.endsWith('-combinator')) {
+        dataTransformer = (response) => {
+          return Metric.convertMetricListResponse(response).map(
+            (currentValue) => {
+              return {
+                ...currentValue,
+                sourceType: 'transformer',
+              }
+            }
+          )
+        }
+      }
+
+      await Metric.api().post(
+        '/metrics',
+        {
+          source: client,
+        },
+        {
+          dataTransformer,
+        }
+      )
+      Metric.commit((state) => {
+        state.fetching = false
+      })
     },
   },
 }

--- a/components/CombinedMetricNode.vue
+++ b/components/CombinedMetricNode.vue
@@ -60,7 +60,7 @@
       v-if="hasSubNodes"
       :id="'subnodes-collapse-' + id"
       class="w-100"
-      :visible="!(type === 'throttle')"
+      :visible="true"
     >
       <b-list-group class="w-100">
         <combined-metric-node

--- a/components/MetricActions.vue
+++ b/components/MetricActions.vue
@@ -100,20 +100,17 @@ export default {
     },
     async editCombinedMetric({ source, id }) {
       try {
-        const { status, data } = await this.$axios.get(
-          `/transformer/${source}/${id}`
-        )
-        if (status === 200) {
-          await this.$router.push({
-            name: 'metric-create_combined_metric',
-            params: {
-              expression: data.expression,
-              combinator: data.transformerId,
-              metric: data.metric,
-              configHash: data.configHash,
-            },
-          })
-        }
+        const { data } = await this.$axios.get(`/transformer/${source}/${id}`)
+
+        await this.$router.push({
+          name: 'metric-create_combined_metric',
+          params: {
+            expression: data.expression,
+            combinator: data.transformerId,
+            metric: data.metric,
+            configHash: data.configHash,
+          },
+        })
       } catch (error) {
         if (error.response.status === 404) {
           this.$toast.error(`Metric not found in combinator config!`)
@@ -135,9 +132,9 @@ export default {
       })
 
       if (confirmed) {
-        const response = await Metric.deleteMetadata([this.metric.id])
+        try {
+          await Metric.deleteMetadata([this.metric.id])
 
-        if (response.status === 200) {
           this.$toast.success(`Successfully deleted ${this.metric.id}!`)
 
           // remove the metric from the vuex store
@@ -145,7 +142,7 @@ export default {
 
           // go back to where the user came from. I hope that is still a valid.
           this.$router.go(-1)
-        } else {
+        } catch (error) {
           this.$toast.error(`Failed to delete the metric!`)
         }
       }

--- a/components/MetricActions.vue
+++ b/components/MetricActions.vue
@@ -60,7 +60,12 @@
       <b-icon-trash scale="1.2" />
     </b-button>
   </b-button-group>
-  <b-icon-exclamation-diamond v-else variant="danger" />
+  <b-icon-exclamation-diamond
+    v-else
+    v-b-tooltip.hover.noninteractive
+    variant="danger"
+    title="Fuzzy cats. Something went wrong. Cannot show metric actions."
+  />
 </template>
 
 <script>

--- a/components/MetricActions.vue
+++ b/components/MetricActions.vue
@@ -1,0 +1,130 @@
+<template>
+  <b-button-group v-if="metric" size="sm" class="shadow-sm">
+    <b-button
+      v-if="showDetails"
+      v-b-tooltip.hover.noninteractive
+      :to="{
+        name: 'metric-metricId',
+        params: { metricId: metric.id },
+      }"
+      title="Open in Metric Library"
+      variant="info"
+    >
+      <b-icon-search />
+    </b-button>
+    <b-button
+      v-if="source && source.isCombinator"
+      v-b-tooltip.hover.noninteractive
+      title="Edit Combinator Expression"
+      @click="editCombinedMetric(metric)"
+    >
+      <b-icon-diagram3-fill />
+    </b-button>
+    <b-button
+      v-if="metric.source"
+      v-b-tooltip.hover.noninteractive
+      title="Show Source Details"
+      :to="{
+        name: 'client-clientId',
+        params: { clientId: metric.source },
+      }"
+      variant="info"
+    >
+      <b-icon-broadcast-pin scale="1.3" />
+    </b-button>
+    <b-button
+      v-if="showDelete && !metric.historic"
+      v-b-tooltip.hover.noninteractive
+      variant="warning"
+      title="Delete the metric"
+      @click="deleteMetric(metric)"
+    >
+      <b-icon-trash scale="1.5" />
+    </b-button>
+  </b-button-group>
+  <b-icon-exclamation-diamond v-else variant="danger" />
+</template>
+
+<script>
+import Metric from '~/models/Metric'
+
+export default {
+  props: {
+    metric: Metric,
+    showDetails: { type: Boolean, default: true },
+    showDelete: { type: Boolean, default: true },
+  },
+  computed: {
+    source() {
+      const metric = Metric.query()
+        .with('sourceRef')
+        .where('id', this.metric.id)
+        .first()
+      if (metric !== null) return metric.sourceRef
+      return null
+    },
+  },
+  methods: {
+    async editCombinedMetric({ source, id }) {
+      try {
+        const { status, data } = await this.$axios.get(
+          `/transformer/${source}/${id}`
+        )
+        if (status === 200) {
+          await this.$router.push({
+            name: 'metric-create_combined_metric',
+            params: {
+              expression: data.expression,
+              combinator: data.transformerId,
+              metric: data.metric,
+              configHash: data.configHash,
+            },
+          })
+        }
+      } catch (error) {
+        if (error.response.status === 404) {
+          this.$toast.error(`Metric not found in combinator config!`)
+        } else {
+          this.$toast.error(`Getting metric expression failed!`)
+        }
+      }
+    },
+    async deleteMetric() {
+      const confirmed = await this.$bvModal.msgBoxConfirm(this.metric.id, {
+        titleHtml: `Are you sure you want to delete the metric?`,
+        buttonSize: 'sm',
+        okVariant: 'danger',
+        okTitle: 'Yes, delete',
+        cancelTitle: 'No, cancel',
+        footerClass: 'p-2',
+        hideHeaderClose: false,
+        centered: true,
+      })
+
+      if (confirmed) {
+        const response = await Metric.deleteMetadata([this.metric.id])
+
+        if (response.status === 200) {
+          this.$toast.success(`Successfully deleted ${this.metric.id}!`)
+
+          // remove the metric from the vuex store
+          Metric.delete(this.metric.id)
+
+          // go back to where the user came from. I hope that is still a valid.
+          this.$router.go(-1)
+        } else {
+          this.$toast.error(`Failed to delete the metric!`)
+        }
+      }
+    },
+  },
+}
+</script>
+
+<style scoped>
+/* Fix positions of tooltips. Known issue, see:
+    https://github.com/bootstrap-vue/bootstrap-vue/issues/1732 */
+.tooltip {
+  top: 0;
+}
+</style>

--- a/components/MetricTable.vue
+++ b/components/MetricTable.vue
@@ -76,14 +76,7 @@
             >
               <b-icon-clipboard-data /> Metadata
             </b-button>
-            <b-button
-              v-if="data.item.sourceRef && data.item.sourceRef.isCombinator"
-              size="sm"
-              @click="editCombinedMetric(data.item)"
-            >
-              <b-icon-pencil-square />
-              Expression
-            </b-button>
+            <MetricActions :metric="data.item" :show-delete="false" />
           </template>
 
           <template #row-details="data">
@@ -100,9 +93,13 @@
 
 <script>
 import Metric from '~/models/Metric'
+import MetricActions from '~/components/MetricActions.vue'
 
 export default {
   name: 'MetricTable',
+  components: {
+    MetricActions,
+  },
   props: {
     filter: { type: String, default: null },
     historic: { type: Boolean, default: null },

--- a/pages/metric/_metricId.vue
+++ b/pages/metric/_metricId.vue
@@ -23,6 +23,7 @@
                 placeholder="Enter metric name"
                 debounce="500"
                 type="search"
+                :trim="true"
                 :state="metricValidationState()"
                 :autofocus="true"
                 @click="onSearchClick()"

--- a/pages/metric/_metricId.vue
+++ b/pages/metric/_metricId.vue
@@ -214,35 +214,7 @@ export default {
     selectedMetric() {
       if (!this.hasSelectedMetric()) return null
 
-      // matchingMetrics only contains json data, not model instances.
-      // However, we need a model instance to use the MetricActions component.
-      // So we insert the metric into the store and then return the model
-      // instance.
-      // This has the side-effect of adding the selected metric to the list
-      // of loaded metrics in the "Metric Workshop" page. While this is a bit
-      // surprising, it accidentally makes sense. If you are looking for a
-      // metric, you likely want to work with it in the workshop as well.
-      // To avoid user confusion, we show a toast message.
-
-      const metric = this.matchingMetrics[0]
-
-      // this is a dumb heuristic, but if the source token starts with
-      // "transformer", we assume it is a transformer and set the source
-      // type accordingly so we can use the `.with('source')` relation.
-      if (metric.source && metric.source.startsWith('transformer')) {
-        metric.sourceType = 'transformer'
-      }
-
-      // stupidly, this gets called a lot, so we only show the toast once.
-      if (!Metric.query().where('id', metric.id).exists()) {
-        this.$toast.info(`Metric ${metric.id} loaded into Metric Workshop.`)
-      }
-
-      // Always adding the metric to the store is fine, so we always have the
-      // latest data.
-      Metric.insert({ data: metric })
-
-      return Metric.find(metric.id)
+      return this.matchingMetrics[0]
     },
   },
   watch: {

--- a/pages/metric/create_combined_metric.vue
+++ b/pages/metric/create_combined_metric.vue
@@ -78,14 +78,7 @@
     <b-card-footer>
       <b-row class="mt-2">
         <b-col>
-          <b-button
-            :to="{
-              name: 'metric-configure',
-            }"
-            variant="danger"
-          >
-            Cancel
-          </b-button>
+          <b-button variant="danger" @click="$router.go(-1)">Cancel</b-button>
         </b-col>
         <b-col />
         <b-col>


### PR DESCRIPTION
Adds some cross-linking for metrics. In particular, it allows one to go to the edit combinator expression from the metric library.

~~These metric actions need a Metric instance, which makes them hard to use.
The issue is that Metric model instaces only come from the vuex ORM
store. But having a ton of metrics in there, makes the Metric Workshop
unusable performance wise.~~

The metric actions don't poke the `Metric` model anymore. This change makes the code a lot less obfuscated. Instead, I also added buttons to add and remove metrics from the workshop explicitly.

This is what I can do without a major backend-API refactor.
It's about time.